### PR TITLE
Broken highlight color in "Total to sell" SpinBox

### DIFF
--- a/src/qtbitcointrader.cpp
+++ b/src/qtbitcointrader.cpp
@@ -1960,6 +1960,7 @@ void QtBitcoinTrader::on_buttonNight_clicked()
 	on_profitLossSpinBox_valueChanged(ui.profitLossSpinBox->value());
 	on_sellThanBuySpinBox_valueChanged(ui.sellThanBuySpinBox->value());
 	on_buyTotalSpend_valueChanged(ui.buyTotalSpend->value());
+	on_sellTotalBtc_valueChanged(ui.sellTotalBtc->value());
 
 	foreach(RuleWidget* currentGroup, ui.tabRules->findChildren<RuleWidget*>())currentGroup->updateStyleSheets();
 


### PR DESCRIPTION
When switching from Night mode to Day mode, the higlight color is not updated in the sellTotalBtc SpinBox. The pull request fixes this, you probably just forgot the line...

![screenshot - 02182014 - 11 24 26 pm](https://f.cloud.github.com/assets/3926232/2201403/93f03854-98ee-11e3-96aa-bc5dac937bf1.png)
